### PR TITLE
Correção de erro semântico da especificação

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1259,7 +1259,7 @@ paths:
   /v1/orders/{orderId}/confirm:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:
@@ -1301,7 +1301,7 @@ paths:
   /v1/orders/{orderId}/requestCancellation:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:
@@ -1340,7 +1340,7 @@ paths:
   /v1/orders/{orderId}/acceptCancellation:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:
@@ -1379,7 +1379,7 @@ paths:
   /v1/orders/{orderId}/denyCancellation:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:
@@ -1420,7 +1420,7 @@ paths:
   /v1/orders/{orderId}/readyForPickup:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:
@@ -1457,7 +1457,7 @@ paths:
   /v1/orders/{orderId}/dispatch:
     post:
       parameters:
-        - name: id
+        - name: orderId
           in: "path"
           required: true
           schema:


### PR DESCRIPTION
Em algumas URLs de pedidos que possuem o parâmetro `orderId` a referência para o parâmetro estava erroneamente apontando para `id`, o que fazia com que houvesse um erro de validação da documentação, conforme _print_ abaixo.

![image](https://user-images.githubusercontent.com/357059/192288678-58fad655-e7c9-4848-a1bd-95ee6c7c3cc0.png)

Este _pull request_ corrige este erro de apontamento.